### PR TITLE
getEBMLByteLength fix: 2 ** n - 2

### DIFF
--- a/src/ebml.ts
+++ b/src/ebml.ts
@@ -52,7 +52,7 @@ export const number = memoize((num: number): Value => {
 });
 
 export const vintEncodedNumber = memoize((num: number): Value => {
-    return bytes(vintEncode(numberToByteArray(num)));
+    return bytes(vintEncode(numberToByteArray(num, getEBMLByteLength(num))));
 });
 
 export const string = memoize((str: string): Value => {

--- a/src/ebml.ts
+++ b/src/ebml.ts
@@ -88,10 +88,12 @@ export const getEBMLByteLength = (num: number): number => {
         return 6;
     } else if (num < 0x1ffffffffffff) {
         return 7;
-    } else if (num < 0x100000000000000) {
+    } else if (num < 0x20000000000000) {
         return 8;
+    } else if (num < 0xffffffffffffff) {
+        throw new Error("EBMLgetEBMLByteLength: number exceeds Number.MAX_SAFE_INTEGER");
     } else {
-        throw new Error(`data size must be less than or equal to ${2 ** 56 - 2}`);
+        throw new Error("EBMLgetEBMLByteLength: data size must be less than or equal to " + (Math.pow(2, 56) - 2));
     }
 };
 

--- a/src/ebml.ts
+++ b/src/ebml.ts
@@ -74,21 +74,21 @@ export const build = (v: EBMLData): Uint8Array => {
 };
 
 export const getEBMLByteLength = (num: number): number => {
-    if (num < 0x80) {
+    if (num < 0x7f) {
         return 1;
-    } else if (num < 0x4000) {
+    } else if (num < 0x3fff) {
         return 2;
-    } else if (num < 0x200000) {
+    } else if (num < 0x1fffff) {
         return 3;
-    } else if (num < 0x10000000) {
+    } else if (num < 0xfffffff) {
         return 4;
-    } else if (num < 0x080000000) {
+    } else if (num < 0x7ffffffff) {
         return 5;
-    } else if (num < 0x04000000000) {
+    } else if (num < 0x3ffffffffff) {
         return 6;
-    } else if (num < 0x02000000000000) {
+    } else if (num < 0x1ffffffffffff) {
         return 7;
-    } else if (num < 0x010000000000000) {
+    } else if (num < 0x100000000000000) {
         return 8;
     } else {
         throw new Error(`data size must be less than or equal to ${2 ** 56 - 2}`);

--- a/src/typedArrayUtils.ts
+++ b/src/typedArrayUtils.ts
@@ -1,14 +1,55 @@
 import * as memoize from "lodash.memoize";
 
 export const numberToByteArray = (num: number, byteLength: number = getNumberByteLength(num)): Uint8Array => {
-    if (byteLength > 4) {
-        throw new Error("Bitwise operators support only signed-32bit.");
+    var byteArray;
+    if (byteLength == 1) {
+        byteArray = new DataView(new ArrayBuffer(1));
+        byteArray.setUint8(0, num);
     }
-    const byteArray = new Uint8Array(byteLength);
-    for (let i = 0; i < byteLength; i++) {
-        byteArray[byteLength - (i + 1)] = (num >> 8 * i) & 0xFF;
+    else if (byteLength == 2) {
+        byteArray = new DataView(new ArrayBuffer(2));
+        byteArray.setUint16(0, num);
     }
-    return byteArray;
+    else if (byteLength == 3) {
+        byteArray = new DataView(new ArrayBuffer(3));
+        byteArray.setUint8(0, num >> 16);
+        byteArray.setUint16(1, num & 0xffff);
+    }
+    else if (byteLength == 4) {
+        byteArray = new DataView(new ArrayBuffer(4));
+        byteArray.setUint32(0, num);
+    }
+    // 4GB (upper limit for int32) should be enough in most cases
+    else if (/* byteLength == 5 && */num < 0xffffffff) {
+        byteArray = new DataView(new ArrayBuffer(5));
+        byteArray.setUint32(1, num);
+    }
+    // Naive emulations of int64 bitwise opreators
+    else if (byteLength == 5) {
+        byteArray = new DataView(new ArrayBuffer(5));
+        byteArray.setUint8(0, num / 0x100000000 | 0);
+        byteArray.setUint32(1, num % 0x100000000);
+    }
+    else if (byteLength == 6) {
+        byteArray = new DataView(new ArrayBuffer(6));
+        byteArray.setUint16(0, num / 0x100000000 | 0);
+        byteArray.setUint32(2, num % 0x100000000);
+    }
+    else if (byteLength == 7) {
+        byteArray = new DataView(new ArrayBuffer(7));
+        byteArray.setUint8(0, num / 0x1000000000000 | 0);
+        byteArray.setUint16(1, num / 0x100000000 & 0xffff);
+        byteArray.setUint32(3, num % 0x100000000);
+    }
+    else if (byteLength == 8) {
+        byteArray = new DataView(new ArrayBuffer(8));
+        byteArray.setUint32(0, num / 0x100000000 | 0);
+        byteArray.setUint32(4, num % 0x100000000);
+    }
+    else {
+        throw new Error("EBML.typedArrayUtils.numberToByteArray: byte length must be less than or equal to 8");
+    }
+    return new Uint8Array(byteArray.buffer)
 };
 
 export const stringToByteArray = memoize((str: string): Uint8Array => {
@@ -16,16 +57,24 @@ export const stringToByteArray = memoize((str: string): Uint8Array => {
 });
 
 export function getNumberByteLength(num: number): number {
-    if (num <= 0xFF) {
+    if (num < 0) {
+        throw new Error("EBML.typedArrayUtils.getNumberByteLength: negative number not implemented");
+    } else if (num < 0x100) {
         return 1;
-    } else if (num <= 0xFFFF) {
+    } else if (num < 0x10000) {
         return 2;
-    } else if (num <= 0xFFFFFF) {
+    } else if (num < 0x1000000) {
         return 3;
-    } else if (num <= 0xFFFFFFFF) {
+    } else if (num < 0x100000000) {
         return 4;
+    } else if (num < 0x10000000000) {
+        return 5;
+    } else if (num < 0x1000000000000) {
+        return 6;
+    } else if (num < 0x20000000000000) {
+        return 7;
     } else {
-        throw new Error("number must be 32bit");
+        throw new Error("EBML.typedArrayUtils.getNumberByteLength: number exceeds Number.MAX_SAFE_INTEGER");
     }
 }
 


### PR DESCRIPTION
https://matroska.org/technical/specs/index.html says

> 1xxx xxxx
> value 0 to  2^7-2

which indicates the upper limit for an one-octet vint should be 0x7f, instead of 0x80.

Plus,

> Any ID where all x's are composed entirely of 1's is a Reserved ID
> There is only one reserved word for Element Size encoding, which is an Element Size encoded to all 1's.